### PR TITLE
Update node.mjs

### DIFF
--- a/.changeset/curly-streets-serve.md
+++ b/.changeset/curly-streets-serve.md
@@ -1,0 +1,5 @@
+---
+"@faktion-com/eslint-config": patch
+---
+
+missing nodejs global

--- a/src/node.mjs
+++ b/src/node.mjs
@@ -8,4 +8,9 @@ export default [
       'no-useless-constructor': 'off',
     },
   },
+  {
+    globals: {
+      NodeJS: true,
+    },
+  },
 ];

--- a/src/node.mjs
+++ b/src/node.mjs
@@ -9,8 +9,10 @@ export default [
     },
   },
   {
-    globals: {
-      NodeJS: true,
+    languageOptions: {
+      globals: {
+        NodeJS: true,
+      },
     },
   },
 ];


### PR DESCRIPTION
added global NodeJS type to be available in your node applications.
eg for typing stuff like `stream: NodeJS.ReadableStream`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration to recognize `NodeJS` as a global variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->